### PR TITLE
client_logout

### DIFF
--- a/TP4_client.py
+++ b/TP4_client.py
@@ -126,6 +126,15 @@ class Client:
 
         Met à jour l'attribut `_username`.
         """
+        logout_message = gloutils.GloMessage(
+            header = gloutils.Headers.AUTH_LOGOUT
+        )
+        response : gloutils.GloMessage = self._send_message_to_server(logout_message)
+        if response.header == gloutils.Headers.OK:
+            print("Logged out")
+            self._username = ""
+        else:
+            print("Failure to logout")
 
     def _menu_authentification(self):
         """"

--- a/TP4_client.py
+++ b/TP4_client.py
@@ -134,7 +134,8 @@ class Client:
             print("Logged out")
             self._username = ""
         else:
-            print("Failure to logout")
+            raise RuntimeError("Failure to logout" + response.header)
+
 
     def _menu_authentification(self):
         """"


### PR DESCRIPTION
Added logout to the client side.
To disconnect, a message with the Auth_logout is sent to the server.
On a success, the username is set to empty.
On a failure, an error message is raised.