### PR TITLE
clientSide_login

### DIFF
--- a/TP4_server.py
+++ b/TP4_server.py
@@ -104,7 +104,28 @@ class Server:
         Si les identifiants sont valides, associe le socket à l'utilisateur et
         retourne un succès, sinon retourne un message d'erreur.
         """
-        return gloutils.GloMessage()
+        received_username = payload.username
+        received_password = payload.password
+        stored_password = self._existing_accounts[received_username]
+        if stored_password is None:
+            error_message = gloutils.GloMessage(
+                header = gloutils.Headers.ERROR,
+                payload = gloutils.ErrorPayload(error_message = "username doesn't exist")
+            )
+            return error_message
+        if stored_password == received_password:
+            # TODO : this comparison should be done with encrypted passwords
+            self._logged_users[received_username] = client_soc
+            ok_message = gloutils.GloMessage(
+                header = gloutils.Headers.OK
+            )
+            return ok_message
+        else:
+            error_message = gloutils.GloMessage(
+                header = gloutils.Headers.ERROR,
+                payload = gloutils.ErrorPayload(error_message = "Invalid password")
+            )
+            return error_message
 
     def _logout(self, client_soc: socket.socket) -> None:
         """Déconnecte un utilisateur."""


### PR DESCRIPTION
Implemented server login
Implementation is not very clean, could be reworked if time permits.

When login, here are the steps : 
1 : verify if username exists in repo, if not returns an error message
2 : verify if stored password is the same as received password, if not returns an error message
3 : if everything checks out, associates the username with the socket and returns ok message.

The comparison should be done with encrypted password, should be added later.